### PR TITLE
Update package.json - require node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/TA2k/ioBroker.tedee.git"
   },
   "engines": {
-    "node": ">= 16"
+    "node": ">= 18"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.6",


### PR DESCRIPTION
As this adapter is no longer tested using (outdated) nodejs16 it should require node 18 minimum.

Please review PR and merge unless there is a big need to support untested node 16 environment.